### PR TITLE
Suggested fixes for pr 6391

### DIFF
--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -51,9 +51,9 @@ t GET libpod/images/$iid/get?format=foo 500
 t GET libpod/images/$PODMAN_TEST_IMAGE_NAME/get?compress=bar 400
 
 for i in $iid ${iid:0:12} $PODMAN_TEST_IMAGE_NAME; do
-  t GET libpod/images/$i/get 200
-  t GET libpod/images/$i/get?compress=true 200
-  t GET libpod/images/$i/get?compress=false 200
+  t GET "libpod/images/$i/get"                200 '[POSIX tar archive]'
+  t GET "libpod/images/$i/get?compress=true"  200 '[POSIX tar archive]'
+  t GET "libpod/images/$i/get?compress=false" 200 '[POSIX tar archive]'
 done
 
 # vim: filetype=sh

--- a/test/apiv2/test-apiv2
+++ b/test/apiv2/test-apiv2
@@ -206,18 +206,22 @@ function t() {
         exit 1
     fi
 
-    if [[ $(file $WORKDIR/curl.result.out) =~ "POSIX tar archive" ]]; then
-        return
-    fi
-
     cat $WORKDIR/curl.headers.out >>$LOG 2>/dev/null || true
-    output=$(< $WORKDIR/curl.result.out)
 
-    # Log results. If JSON, filter through jq for readability
-    if egrep -qi '^Content-Type: application/json' $WORKDIR/curl.headers.out; then
-        jq . <<<"$output" >>$LOG
-    else
+    # Log results, if text. If JSON, filter through jq for readability.
+    content_type=$(sed -ne 's/^Content-Type:[ ]\+//pi' <$WORKDIR/curl.headers.out)
+
+    if [[ $content_type =~ /octet ]]; then
+        output="[$(file --brief $WORKDIR/curl.result.out)]"
         echo "$output" >>$LOG
+    else
+        output=$(< $WORKDIR/curl.result.out)
+
+        if [[ $content_type =~ application/json ]]; then
+            jq . <<<"$output" >>$LOG
+        else
+            echo "$output" >>$LOG
+        fi
     fi
 
     # Test return code
@@ -236,6 +240,7 @@ function t() {
         return
     fi
 
+    local i
     for i; do
         case "$i" in
             # Exact match on json field


### PR DESCRIPTION
Deal with API returning binary (Content-Type =~ 'octet').
When so, set $output to the output of 'file'.

Add content-type check to new /get tests. And, quote
URLs with special shell character '?'

Bug fix: in 't' helper, declare loop var $i as local
to avoid contaminating caller

Signed-off-by: Ed Santiago <santiago@redhat.com>